### PR TITLE
Feature/handle sequelize connections errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,7 +35,7 @@ internals.configure = function (opts) {
       return Models.applyRelations(Models.load(files, opts.sequelize.import.bind(opts.sequelize)));
     }, (err) => {
       return Promise.reject(
-        new Error("An error occured while attempting to connect to DB [" + opts.name + "], please check the configuration.")
+        new Error("An error occurred while attempting to connect to DB [" + opts.name + "], please check the configuration. Details : " + err.message)
       );
     })
     .then((models) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,8 +32,11 @@ internals.configure = function (opts) {
   return opts.sequelize.authenticate()
     .then(() => {
       const files = Models.getFiles(opts.models);
-      const models = Models.applyRelations(Models.load(files, opts.sequelize.import.bind(opts.sequelize)));
-      return models;
+      return Models.applyRelations(Models.load(files, opts.sequelize.import.bind(opts.sequelize)));
+    }, (err) => {
+      return Promise.reject(
+        new Error("An error occured while attempting to connect to DB [" + opts.name + "], please check the configuration.")
+      );
     })
     .then((models) => {
       if (opts.sync) {
@@ -45,7 +48,7 @@ internals.configure = function (opts) {
     .then((database) => {
       if (opts.onConnect) {
         let maybePromise = opts.onConnect(opts.sequelize);
-        if (maybePromise && typeof maybePromise.then === 'function') 
+        if (maybePromise && typeof maybePromise.then === 'function')
           return maybePromise.then(() => database);
       }
       return database;
@@ -77,6 +80,8 @@ exports.register = function(server, options, next) {
         .then((db) => {
           server.expose(opts.name, db);
           return Promise.resolve(db);
+        }, (err) => {
+          return Promise.reject(err)
         })
     ]);
   }, []);
@@ -84,6 +89,8 @@ exports.register = function(server, options, next) {
   Promise.all(configured)
     .then(() => {
       return next()
+    },(err) => {
+      return next(err)
     })
     .catch((err) => {
       return next(err)

--- a/test/index.js
+++ b/test/index.js
@@ -7,9 +7,6 @@ const Sinon = require('sinon');
 const Hapi = require('hapi');
 const Sequelize = require('sequelize');
 
-// Module globals
-const internals = {};
-
 // Test shortcuts
 const lab = exports.lab = Lab.script();
 const test = lab.test;
@@ -28,7 +25,7 @@ lab.suite('hapi-sequelize', () => {
       dialect: 'mysql'
     });
 
-    const onConnect = function (database) {
+    const onConnect = function () {
       server.log('onConnect called');
     };
 
@@ -64,7 +61,7 @@ lab.suite('hapi-sequelize', () => {
     const server = new Hapi.Server();
     server.connection();
 
-    const onConnect = function (database) {
+    const onConnect = function () {
       server.log('onConnect called');
     };
 

--- a/test/index.js
+++ b/test/index.js
@@ -30,7 +30,7 @@ lab.suite('hapi-sequelize', () => {
 
     const onConnect = function (database) {
       server.log('onConnect called');
-    }
+    };
 
     const spy = Sinon.spy(onConnect);
 
@@ -56,6 +56,44 @@ lab.suite('hapi-sequelize', () => {
         expect(tables.length).to.equal(6);
         done();
       });
+    })
+  });
+
+  test('plugin fails to register when Sequelize fails to connect', { parallel: true }, (done) => {
+
+    const server = new Hapi.Server();
+    server.connection();
+
+    const onConnect = function (database) {
+      server.log('onConnect called');
+    };
+
+    const spy = Sinon.spy(onConnect);
+
+    const sequelize = new Sequelize('shop', 'root', '', {
+      host: '127.0.0.1',
+      port: 3307,
+      dialect: 'mysql'
+    });
+
+    server.register([
+      {
+        register: require('../lib'),
+        options: [
+          {
+            name: 'shop',
+            models: ['./test/models/**/*.js'],
+            sequelize: sequelize,
+            sync: true,
+            forceSync: true,
+            onConnect: spy
+          }
+        ]
+      }
+    ], (err) => {
+      expect(err).to.exist();
+      expect(err.message).to.include('ECONNREFUSED');
+      done();
     })
   });
 


### PR DESCRIPTION
Handles errors generated by sequelize on plugin registering during the ```.authenticate()``` call by logging the error and not starting the server.